### PR TITLE
fix auth.py GET route for session method

### DIFF
--- a/ddsurveys/blueprints/auth.py
+++ b/ddsurveys/blueprints/auth.py
@@ -174,7 +174,7 @@ def signin() -> ResponseReturnValue:
         return jsonify({"token": token}), HTTPStatus.OK
 
 
-@auth.route("/me", methods=["GET"])
+@auth.route("/auth/me", methods=["GET"])
 @jwt_required()
 def session() -> ResponseReturnValue:
     current_user = get_jwt_identity()


### PR DESCRIPTION
When trying to sign in, the sign in is successful but does not direct to /projects due to validateToken (in AuthContext.tsx) failing due to  const response = await GET('/auth/me'); returning code "422 Unprocessable Content" which was because the GET request was not being served by any backend method. 
